### PR TITLE
Updating language for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Radiance65 App
-
 [![CI](https://github.com/FuLygon/sr65-app/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/FuLygon/sr65-app/actions/workflows/ci.yaml)
 [![GoReportCard](https://goreportcard.com/badge/github.com/FuLygon/sr65-app)](https://goreportcard.com/report/github.com/FuLygon/sr65-app)
-
+# Click here for Vietnamese readme [![vn](https://img.shields.io/badge/lang-vn-red.svg)](https://github.com/whoismaiko/sr65-app/blob/main/Readme-VI.md)
 Unofficial media conversion tool for **SR Studio Radiance65** keyboard screen.
 
 ## Download

--- a/Readme-VI.md
+++ b/Readme-VI.md
@@ -1,0 +1,22 @@
+# Radiance65 App
+
+[![CI](https://github.com/FuLygon/sr65-app/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/FuLygon/sr65-app/actions/workflows/ci.yaml)
+[![GoReportCard](https://goreportcard.com/badge/github.com/FuLygon/sr65-app)](https://goreportcard.com/report/github.com/FuLygon/sr65-app)
+
+Công cụ chuyển đổi hình ảnh không chính thức cho màn hình trên bàn phím **SR Studio Radiance65**.
+
+## Download
+
+[![release](https://img.shields.io/github/release/FuLygon/sr65-app.svg?style=flat)](https://github.com/FuLygon/sr65-app/releases)
+
+## Các định dạng hỗ trợ
+- Ảnh: `png`, `jpg/jpeg`, `gif`, `bmp`, `webp`
+- Video: `mp4`, `mkv`, `flv`, `ts`, `webm`
+
+
+
+> [!NOTE]
+> Để keymap, add macros, chỉnh layout, etc... vui lòng sử dụng [Vial](https://get.vial.today).
+
+> [!CAUTION]
+> Các phần mềm diệt Virus có thể đánh dấu phần mềm này là độc hại. Đây là một **cảnh báo sai**. Bạn có thể dựa vào [Readme Tiếng Anh](#build-from-source) để tự build.


### PR DESCRIPTION
Added Vietnamese Readme, including a shortcut on EN Readme to VN Readme.
P/S: The Vietnamese version is very straight forward without any additional info. Users can base on [T-Order's SR65 Guide](https://docs.google.com/document/d/12fKrF3RXfL-cvRMZSMGXnrLyqC6nCm6NgljLXuLErWA/edit?usp=sharing) to transfer the files to keeb.